### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 Slurm Meadow for eHive
 ======================
 
+> [!IMPORTANT]  
+> As per eHive version 2.7.0, all the meadows other than `SLURM` and `Local` are deprecated and not supported anymore.
+> `SLURM` is natively supported by eHive, and this fork is not needed or supported any longer.
+> 
+> This repository is going to be archived soon ~1Q2025.
+>
+> Please, do not hesitate to contact us, should this be a problem.
+
 [eHive](https://github.com/Ensembl/ensembl-hive) is a system for running computation pipelines on distributed computing resources - clusters, farms or grids.
 
 This repository is the implementation of eHive's _Meadow_ interface for the SLURM job scheduler.
@@ -12,5 +20,5 @@ Commits will eventually be fed back to the original repository.
 Version numbering and compatibility
 -----------------------------------
 
-All tags and branches (except _master_) have been stripped off, to
+All tags and branches (except _main_) have been stripped off, to
 emphasize that this is a development project.


### PR DESCRIPTION
At EMBL-EBI, we transitioned to use SLURM instead of LSF as job scheduling system.
We are now - as per version 2.7.0 - supporting SLURM natively on eHive, and in no need of this repository/codebase anymore.